### PR TITLE
feat(yml): use strings where expected

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
     project:
       default:
         target: 50
-        threshold: 1
+        threshold: "1"
         base: auto
     patch:
       default:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -31,8 +31,8 @@ services:
       - ./environments/domain.env
       - ./environments/letsencrypt.env
     ports:
-      - 443:443
-      - 80:80
+      - "443:443"
+      - "80:80"
     volumes:
       - type: bind
         source: ./koffee.subfolder.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./environments/domain.env
       - ./environments/koffee.env
     ports:
-      - 8080:8080
+      - "8080:8080"
     depends_on:
       - mongo
     restart: unless-stopped


### PR DESCRIPTION
Codecov expects a string for the threshold value, docker recommends using one for ports.